### PR TITLE
NGワードに該当するアカウントを自動的に除外リストに加える。

### DIFF
--- a/harvest/.gitignore
+++ b/harvest/.gitignore
@@ -1,3 +1,4 @@
 .chalice/deployments/
 .chalice/venv/
 .chalice/deployed/
+/*.json

--- a/harvest/chalicelib/settings.py.example
+++ b/harvest/chalicelib/settings.py.example
@@ -3,12 +3,11 @@ TwitterConsumerSecret = ''
 TwitterAccessToken = ''
 TwitterAccessTokenSecret = ''
 
-ExcludeAccounts = (
-)
 NGWords = (
 )
 
 LatestTweetIDFile = 'latest_tweet.txt'
+CensoredAccountsFile = 'censored_accounts.json'
 
 S3Bucket = ''
 TweetStorageDir = 'harvest/tweets'

--- a/harvest/chalicelib/twitter.py
+++ b/harvest/chalicelib/twitter.py
@@ -1,20 +1,52 @@
 from __future__ import annotations
 
+import copy
+import json
 import re
 import unicodedata
 from datetime import datetime
 from logging import getLogger
 from typing import (
-    cast, Any, Dict, List,
-    Optional, Sequence, Union,
+    cast, Any, Dict, List, Optional, Union,
 )
 
 import pytz
 import tweepy  # type: ignore
 
-from . import freequest, settings, timezone
+from . import freequest, settings, storage, timezone
 
 logger = getLogger(__name__)
+
+
+class CensoredAccounts:
+    def __init__(
+        self,
+        fileStorage: storage.SupportStorage,
+        filepath: str,
+    ):
+        self.fileStorage = fileStorage
+        self.filepath = filepath
+        self.accounts: List[str] = []
+        text = fileStorage.get_as_text(filepath)
+        if text:
+            self.accounts = cast(List[str], json.loads(text))
+
+    def save(self) -> None:
+        stream = self.fileStorage.get_output_stream(self.filepath)
+        js = json.dumps(self.accounts, indent=2)
+        stream.write(js.encode('utf-8'))
+        self.fileStorage.close_output_stream(stream)
+
+    def exists(self, account: str) -> bool:
+        return account in self.accounts
+
+    def add(self, account: str) -> None:
+        if self.exists(account):
+            return
+        self.accounts.append(account)
+
+    def list(self) -> List[str]:
+        return copy.deepcopy(self.accounts)
 
 
 class TweetCopy:
@@ -168,7 +200,7 @@ class Agent:
         fetch_count: int = 100,
         max_repeat: int = 10,
         since_id: Optional[int] = None,
-        exclude_accounts: Sequence[str] = (),
+        censored: Optional[CensoredAccounts] = None,
     ) -> List[TweetCopy]:
 
         max_id: Optional[int] = None
@@ -181,8 +213,6 @@ class Agent:
         # 取得できるのは高々5件程度だろう。
         for i in range(max_repeat):
             q = '#FGO周回カウンタ -filter:retweets'
-            for account in exclude_accounts:
-                q += f' -from:{account}'
             kwargs = {
                 'q': q,
                 'count': fetch_count,
@@ -197,13 +227,33 @@ class Agent:
             tweets = self.api.search(**kwargs)
             logger.info('>>> fetched %s tweets', len(tweets))
 
-            if tweets:
-                wrapped = [
-                    TweetCopy(tw) for tw in tweets
-                        if self.appropriate_tweet(tw)
-                ]
-                objects.extend(wrapped)
+            wrapped = []
+            for tw in tweets:
+                screen_name = tw.user.screen_name
+                if censored and censored.exists(screen_name):
+                    logger.warning(
+                        "censored account's tweet: %s",
+                        tw.id,
+                    )
+                    continue
 
+                if not self.appropriate_tweet(tw):
+                    logger.warning('inappropriate tweet: %s', tw.id)
+                    if not censored:
+                        continue
+
+                    censored.add(screen_name)
+                    logger.warning(
+                        'account %s is added the censored list',
+                        screen_name,
+                    )
+                    continue
+
+                wrapped.append(TweetCopy(tw))
+            objects.extend(wrapped)
+
+            # 取得数が取得可能件数より少ないので、もうフェッチ可能な
+            # データはないと判断できる。
             if len(tweets) < fetch_count:
                 return objects
 
@@ -253,7 +303,7 @@ class Agent:
         logger.info('>>> fetched %s tweets', len(tweets))
         return {
             tw.id: TweetCopy(tw) for tw in tweets
-                if self.appropriate_tweet(tw)
+            if self.appropriate_tweet(tw)
         }
 
 


### PR DESCRIPTION
これまでは手動で `settings.ExcludeAccounts` に加える操作をやっていたが、メンテナンスコストを下げられるように以下のとおり変更する。

- 除外リストを settings から切り離してリポジトリ管理対象外とし、単独で更新可能とする
- 決められた条件に合致するアカウントはこの除外リストに自動で追加する

条件に合致しないが除外したいアカウントについては、引き続き手動のメンテナンスが必要。ただし運用を続けながら自動判定の適用条件を拡大していくことも可能だろう。